### PR TITLE
fix result of gas when gas reading is disabled

### DIFF
--- a/Adafruit_BME680.cpp
+++ b/Adafruit_BME680.cpp
@@ -375,6 +375,8 @@ bool Adafruit_BME680::endReading(void) {
       gas_resistance = 0;
       //Serial.println("Gas reading unstable!");
     }
+  } else {
+    gas_resistance = NAN;
   }
 
   return true;


### PR DESCRIPTION
If you disable the gas reading with .setGasHeater(0,0), the .performReading() will continue to return the latest read result before the .setGasHeater(0,0), instead of returning NAN, like when the other readings (temp, humidity, pressure) return when they are disabled.