### PR TITLE
Enable/disable gas heater and fix for gas_resistance 

### DIFF
--- a/Adafruit_BME680.cpp
+++ b/Adafruit_BME680.cpp
@@ -93,6 +93,8 @@ Adafruit_BME680::Adafruit_BME680(int8_t cspin, int8_t mosipin, int8_t misopin, i
     calibration data in preparation for sensor reads.
 
     @param  addr Optional parameter for the I2C address of BME680. Default is 0x77
+    @param  initSettings Optional parameter for initializing the sensor settings.
+    Default is true.
     @return True on sensor initialization success. False on failure.
 */
 /**************************************************************************/

--- a/Adafruit_BME680.cpp
+++ b/Adafruit_BME680.cpp
@@ -96,7 +96,7 @@ Adafruit_BME680::Adafruit_BME680(int8_t cspin, int8_t mosipin, int8_t misopin, i
     @return True on sensor initialization success. False on failure.
 */
 /**************************************************************************/
-bool Adafruit_BME680::begin(uint8_t addr) {
+bool Adafruit_BME680::begin(uint8_t addr, bool initSettings) {
   _i2caddr = addr;
 
   if (_cs == -1) {
@@ -170,12 +170,15 @@ bool Adafruit_BME680::begin(uint8_t addr) {
   Serial.print("SW Error = "); Serial.println(gas_sensor.calib.range_sw_err);
 #endif
 
-  setTemperatureOversampling(BME680_OS_8X);
-  setHumidityOversampling(BME680_OS_2X);
-  setPressureOversampling(BME680_OS_4X);
-  setIIRFilterSize(BME680_FILTER_SIZE_3);
-  setGasHeater(320, 150); // 320*C for 150 ms
-
+  if (initSettings) {
+    setTemperatureOversampling(BME680_OS_8X);
+    setHumidityOversampling(BME680_OS_2X);
+    setPressureOversampling(BME680_OS_4X);
+    setIIRFilterSize(BME680_FILTER_SIZE_3);
+    setGasHeater(320, 150); // 320*C for 150 ms
+  } else {
+    setGasHeater(0, 0);
+  }
   // don't do anything till we request a reading
   gas_sensor.power_mode = BME680_FORCED_MODE;
 
@@ -375,6 +378,8 @@ bool Adafruit_BME680::endReading(void) {
       gas_resistance = 0;
       //Serial.println("Gas reading unstable!");
     }
+  } else {
+    gas_resistance = NAN; 
   }
 
   return true;
@@ -394,9 +399,11 @@ bool Adafruit_BME680::setGasHeater(uint16_t heaterTemp, uint16_t heaterTime) {
 
   if ( (heaterTemp == 0) || (heaterTime == 0) ) {
     // disabled!
+    gas_sensor.gas_sett.heatr_ctrl = BME680_DISABLE_HEATER;
     gas_sensor.gas_sett.run_gas = BME680_DISABLE_GAS_MEAS;
     _gasEnabled = false;
   } else {
+    gas_sensor.gas_sett.heatr_ctrl = BME680_ENABLE_HEATER;
     gas_sensor.gas_sett.run_gas = BME680_ENABLE_GAS_MEAS;
     _gasEnabled = true;
   }

--- a/Adafruit_BME680.h
+++ b/Adafruit_BME680.h
@@ -50,7 +50,7 @@ class Adafruit_BME680_Unified : public Adafruit_Sensor
 public:
     Adafruit_BME680_Unified(int32_t sensorID = -1);
 
-    bool  begin(uint8_t addr = BME680_ADDRESS);
+    bool  begin(uint8_t addr = BME680_DEFAULT_ADDRESS, bool initSettings = true);
     void  getTemperature(float *temp);
     void  getPressure(float *pressure);
     float pressureToAltitude(float seaLevel, float atmospheric, float temp);

--- a/Adafruit_BME680.h
+++ b/Adafruit_BME680.h
@@ -75,7 +75,7 @@ class Adafruit_BME680
     Adafruit_BME680(int8_t cspin = -1);
     Adafruit_BME680(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
 
-    bool  begin(uint8_t addr = BME680_DEFAULT_ADDRESS);
+    bool  begin(uint8_t addr = BME680_DEFAULT_ADDRESS, bool initSettings = true);
     float readTemperature(void);
     float readPressure(void);
     float readHumidity(void);


### PR DESCRIPTION
This pull request disables and enables the gas heater in the method setGasHeater. Furthermore, I adjusted Adafruit_BME680::begin in order to make the initialization of the sensor settings optional. 
I also fixed the gas_resistance which is now reset if the gas heater is turned off.