### PR TITLE
Fix 49 days rollover

### DIFF
--- a/Adafruit_BME680.cpp
+++ b/Adafruit_BME680.cpp
@@ -77,6 +77,8 @@ Adafruit_BME680::Adafruit_BME680(int8_t cspin)
 /**************************************************************************/
 Adafruit_BME680::Adafruit_BME680(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin)
   : _cs(cspin)
+  , _meas_start(0)
+  , _meas_period(0)
 {
   _BME680_SoftwareSPI_MOSI = mosipin;
   _BME680_SoftwareSPI_MISO = misopin;

--- a/Adafruit_BME680.h
+++ b/Adafruit_BME680.h
@@ -23,7 +23,7 @@
 #ifndef __BME680_H__
 #define __BME680_H__
 
-#if (ARDUINO >= 100)
+#if defined(ARDUINO) && (ARDUINO >= 100)
  #include "Arduino.h"
 #else
  #include "WProgram.h"
@@ -72,6 +72,9 @@ public:
 class Adafruit_BME680
 {
   public:
+    static constexpr int reading_not_started = -1;
+    static constexpr int reading_complete = 0;
+
     Adafruit_BME680(int8_t cspin = -1);
     Adafruit_BME680(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
 
@@ -104,14 +107,25 @@ class Adafruit_BME680
      */
     bool endReading(void);
 
+    /** @brief Get remaining time for an asynchronous reading.
+     *  @return Remaining millis until endReading will not block if invoked.
+     *
+     *  If the asynchronous reading is still in progress, how many millis until its completion.
+     *  If the asynchronous reading is completed, 0.
+     *  If no asynchronous reading has started, -1 or Adafruit_BME680::reading_not_started.
+     *
+     *  Does not block.
+     */
+    int remainingReadingMillis(void);
+
     /// Temperature (Celsius) assigned after calling performReading() or endReading()
     float temperature;
     /// Pressure (Pascals) assigned after calling performReading() or endReading()
-    float pressure;
+    uint32_t pressure;
     /// Humidity (RH %) assigned after calling performReading() or endReading()
     float humidity;
     /// Gas resistor (ohms) assigned after calling performReading() or endReading()
-    float gas_resistance;
+    uint32_t gas_resistance;
   private:
 
     bool _filterEnabled, _tempEnabled, _humEnabled, _presEnabled, _gasEnabled;

--- a/Adafruit_BME680.h
+++ b/Adafruit_BME680.h
@@ -72,7 +72,9 @@ public:
 class Adafruit_BME680
 {
   public:
+    /// Value returned by remainingReadingMillis indicating no asynchronous reading has been initiated by beginReading.
     static constexpr int reading_not_started = -1;
+    /// Value returned by remainingReadingMillis indicating asynchronous reading is complete and calling endReading will not block.
     static constexpr int reading_complete = 0;
 
     Adafruit_BME680(int8_t cspin = -1);

--- a/Adafruit_BME680.h
+++ b/Adafruit_BME680.h
@@ -118,7 +118,8 @@ class Adafruit_BME680
     uint8_t _i2caddr;
     int32_t _sensorID;
     int8_t _cs;
-    unsigned long _meas_end;
+    unsigned long _meas_start;
+    uint16_t _meas_period;
 
     uint8_t spixfer(uint8_t x);
 


### PR DESCRIPTION
A pass of bug squashes, cleanups, additions and warning fixes as I took this library into a project.

I needed to keep the microcontroller busy feeding a display, not waiting for a sensor to endMeasurement.

Also, this project will remain powered for more than 49.7 days at a time, and the original wait strategy would hang you if you were doing a measurement at the uint32 millis rollover.