### PR TITLE
Fix remaining time bug

### DIFF
--- a/Adafruit_BME680.cpp
+++ b/Adafruit_BME680.cpp
@@ -394,8 +394,8 @@ int Adafruit_BME680::remainingReadingMillis(void)
 {
     if (_meas_start != 0) {
         /* A measurement is already in progress */
-        int remaing_time = (millis() - _meas_start) - (int)_meas_period;
-        return remaing_time < 0 ? reading_complete : remaing_time;
+        int remaining_time = (int)_meas_period - (millis() - _meas_start);
+        return remaining_time < 0 ? reading_complete : remaining_time;
     }
     return reading_not_started;
 }


### PR DESCRIPTION
In the recent update to fix uint32 millis rollover, I backwardsed math.
When your loop is slow, the calculation reaches 0, then counts up
forever.  When your loop is fast, it lies and says the result is ready
immediately (causing blocking, but no other ill effect).

This change subtracts elapsed time _from_ measure period - as is
intuitively necessary.

The beginReading, poll remainingReadMillis, endReading strategy now
blocks a Particle Photon for 0.25ms on average when checking
remainingReadMillis correctly.