### PR TITLE
Fix variable name in debug code

### DIFF
--- a/Adafruit_BME680.cpp
+++ b/Adafruit_BME680.cpp
@@ -335,7 +335,7 @@ bool Adafruit_BME680::endReading(void) {
   int remaining_millis = remainingReadingMillis();
   if (remaining_millis > 0) {
 #ifdef BME680_DEBUG
-    Serial.print("Waiting (ms) "); Serial.println(meas_period);
+    Serial.print("Waiting (ms) "); Serial.println(remaining_millis);
 #endif
     delay(static_cast<unsigned int>(remaining_millis) * 2); /* Delay till the measurement is ready */
   }


### PR DESCRIPTION
I changed the variable name in the debug code from `meas_period` to `remaining_millis` to adjust for the changes in 7e5a79b6bc3e1e56d32506f0eb03e5f188887345. 

This should fix #23.

This is my first pull request so i hope everything is fine :-)