### PR TITLE
Fixed compiler warning for gas_resistance.

### DIFF
--- a/Adafruit_BME680.cpp
+++ b/Adafruit_BME680.cpp
@@ -415,7 +415,7 @@ bool Adafruit_BME680::endReading(void) {
       // Serial.println("Gas reading unstable!");
     }
   } else {
-    gas_resistance = NAN;
+    gas_resistance = 0;
   }
 
   return true;


### PR DESCRIPTION
Scope:
- Reverting commit [aa7e814]. Not sure why the compiler warning has been reintroduced, the internal data type will never change during compile time: `uint32_t Adafruit_BME680::gas_resistance.`

Known limitations:
- None.

Tests:
- bme.setGasHeater(0, 0); // Will internally set _gasEnabled to false, bypassing gas readings and returning 0 as default value, as expected.