### PR TITLE
Clear warning `unused parameter 'intf_ptr' [-Werror=unused-parameter]`

### DIFF
--- a/Adafruit_BME680.cpp
+++ b/Adafruit_BME680.cpp
@@ -603,6 +603,7 @@ static int8_t spi_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t len,
 }
 
 static void delay_usec(uint32_t us, void *intf_ptr) {
+  (void)intf_ptr; // Unused parameter
   delayMicroseconds(us);
   yield();
 }


### PR DESCRIPTION
This warning is generated when `--warnings all` is supplied to the Arduino CLI.