### PR TITLE
Allow setting wire port after sensor has been created

### DIFF
--- a/Adafruit_BME680.h
+++ b/Adafruit_BME680.h
@@ -74,6 +74,7 @@ public:
   Adafruit_BME680(TwoWire *theWire = &Wire);
   Adafruit_BME680(int8_t cspin, SPIClass *theSPI = &SPI);
   Adafruit_BME680(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
+  void setWire(TwoWire *theWire = &Wire) {_wire = theWire;}
 
   bool begin(uint8_t addr = BME68X_DEFAULT_ADDRESS, bool initSettings = true);
   float readTemperature();


### PR DESCRIPTION
in most Arduino libraries its possible to change the wire port after the sensor structure has been created.
For example the main program initialized the sensor with: 
Adafruit_BME680 bme680; 

Then the main program is searching for the sensor on the available wire interfaces.
Then we provide that wire interface to the driver which keeps it in the _wire variable.

Either we provide opportunity to set wire interface in begin() function or with the proposed change in the file Adafruit_BME689.h by adding the following line:

void setWire(TwoWire *theWire = &Wire) {_wire = theWire;}

which exposed the private variable _wire.