### PR TITLE
Fix sample to choose between Wire and Wire1 for QTPy usage

### DIFF
--- a/examples/bme680test/bme680test.ino
+++ b/examples/bme680test/bme680test.ino
@@ -20,7 +20,6 @@
 #include <Adafruit_Sensor.h>
 #include "Adafruit_BME680.h"
 
-#define WIRE &Wire
 #define BME_SCK 13
 #define BME_MISO 12
 #define BME_MOSI 11
@@ -28,8 +27,8 @@
 
 #define SEALEVELPRESSURE_HPA (1013.25)
 
-Adafruit_BME680 bme(WIRE); // I2C
-//Adafruit_BME680 bme(&Wire1); // I2C on specified bus, ex: Wire1
+Adafruit_BME680 bme(&Wire); // I2C
+//Adafruit_BME680 bme(&Wire1); // example of I2C on another bus
 //Adafruit_BME680 bme(BME_CS); // hardware SPI
 //Adafruit_BME680 bme(BME_CS, BME_MOSI, BME_MISO,  BME_SCK);
 

--- a/examples/bme680test/bme680test.ino
+++ b/examples/bme680test/bme680test.ino
@@ -29,6 +29,7 @@
 #define SEALEVELPRESSURE_HPA (1013.25)
 
 Adafruit_BME680 bme(WIRE); // I2C
+//Adafruit_BME680 bme(&Wire1); // I2C on specified bus, ex: Wire1
 //Adafruit_BME680 bme(BME_CS); // hardware SPI
 //Adafruit_BME680 bme(BME_CS, BME_MOSI, BME_MISO,  BME_SCK);
 

--- a/examples/bme680test/bme680test.ino
+++ b/examples/bme680test/bme680test.ino
@@ -20,6 +20,7 @@
 #include <Adafruit_Sensor.h>
 #include "Adafruit_BME680.h"
 
+#define WIRE &Wire
 #define BME_SCK 13
 #define BME_MISO 12
 #define BME_MOSI 11
@@ -27,7 +28,7 @@
 
 #define SEALEVELPRESSURE_HPA (1013.25)
 
-Adafruit_BME680 bme; // I2C
+Adafruit_BME680 bme(WIRE); // I2C
 //Adafruit_BME680 bme(BME_CS); // hardware SPI
 //Adafruit_BME680 bme(BME_CS, BME_MOSI, BME_MISO,  BME_SCK);
 


### PR DESCRIPTION
When attempting to use bme680test.ino, it wasn't evident when using I2C interface that you might need to choose between two different buses.  The changes to the sample is to show that this can be chosen in the code and does not require a change in the library.

There should be no limitations to this change.  It just relies on not choosing the default specified by the library.

Tested using a QTPy ESP32 and BME688 connected via STEMMA QT

Reference: https://learn.adafruit.com/scanning-i2c-addresses