### PR TITLE
Removed dependencies which are only used in exaples

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library for BME680 and BME688 humidity and pressure sensors.
 category=Sensors
 url=https://github.com/adafruit/Adafruit_BME680
 architectures=*
-depends=Adafruit Unified Sensor, Adafruit GFX Library, Adafruit SSD1306, Adafruit BusIO
+depends=Adafruit Unified Sensor, Adafruit BusIO


### PR DESCRIPTION
This changes the `depends` line in `library.properties` to no longer include *Adafruit GFX* and *Adafruit SSD1306*. It seems like those are only included because it is used in the [bme680oled](https://github.com/adafruit/Adafruit_BME680/tree/master/examples/bme680oled) example. However, including them there means that they are installed automatically by PlatformIO and the Arduino IDE will also prompt to download these dependencies. In many cases, that's not needed.

In my case, this was a problem because i had a slightly customized version of Adafruit GFX already in my project lib folder, which then conflicted with the one PlatformIO downloaded automatically.